### PR TITLE
Remove tests from API setup

### DIFF
--- a/doc/api_setup.py
+++ b/doc/api_setup.py
@@ -12,7 +12,8 @@ api_names = []
 for f in api_files:
     f_parts = f.split('.')
     if (len(f_parts) == 3):
-        api_names.append(f_parts[0] + '.' + f_parts[1])
+        if f_parts[1] != 'tests':
+            api_names.append(f_parts[0] + '.' + f_parts[1])
 
 # Open API/index.md to modify
 f_api = open(api_path + '/index.md', 'a')


### PR DESCRIPTION
The API section has an eva.tests package page, this is a basically blank page. All that is in this directory of eva are the config YAMLs and sample data for the tests, no code, so I think it should be removed. This PR does that with a small change to the python script. 