### PR TITLE
HOTFIX: Missing directory causing docs not to show

### DIFF
--- a/doc/eva_user_guide/plotting_backends/index.md
+++ b/doc/eva_user_guide/plotting_backends/index.md
@@ -7,6 +7,6 @@ This section descibes the plotting backends that are supported in eva.
 :hidden:
 :maxdepth: 2
 
-Batch plotting using EMCpy backend <EMCpy/index>
+Batch plotting using EMCPy backend <EMCPy/index>
 Interactive plotting using hvPlot <hvplot/index>
 ```


### PR DESCRIPTION
## Description

Changed directory from `EMCpy` to `EMCPy`, but failed to do so in the plotting backend `index.md` file. Caused documentation to not show up on website.
